### PR TITLE
Create .devcontainer.json

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,3 @@
+{
+    "image": "mcr.microsoft.com/vscode/devcontainers/python"
+}


### PR DESCRIPTION
This works around the missing "Izma" dependency, by temporarily using our maintained Python image, as opposed to the general-purpose base image (which includes a broken Python installation).